### PR TITLE
Correct order for left aligned bars

### DIFF
--- a/Chart.HorizontalBar.js
+++ b/Chart.HorizontalBar.js
@@ -67,10 +67,10 @@
 
 			// It'd be nice to keep this class totally generic to any rectangle
 			// and simply specify which border to miss out.
-			ctx.moveTo(this.left, bottom);
-			ctx.lineTo(this.left, top);
-			ctx.lineTo(right, top);
-			ctx.lineTo(right, bottom);
+			ctx.moveTo(this.left, top);
+  			ctx.lineTo(right, top);
+  			ctx.lineTo(right, bottom);
+			ctx.lineTo(this.left, bottom);
 			ctx.fill();
 			if (this.showStroke){
 				ctx.stroke();


### PR DESCRIPTION
The left border should be missing instead of the bottom border, till a generic solution is available
